### PR TITLE
Add imported-cluster-version-management annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-clusters",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "engines": {
     "node": ">=20.0.0"

--- a/pkg/virtual-clusters/assets/icon-virtual-clusters.svg
+++ b/pkg/virtual-clusters/assets/icon-virtual-clusters.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: $$$/GeneralStr/196=Adobe Illustrator 27.6.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#3D98D3;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#3D98D3;}
+</style>
+<g id="Layer_1">
+</g>
+<g id="Layer_2">
+	<path class="st0" d="M44.7,4.5H15.3L0.5,30l14.7,25.5h29.5L59.5,30L44.7,4.5z M42.4,51.5H17.6L5.1,30L17.6,8.5h24.9L54.9,30
+		L42.4,51.5z"/>
+	<g>
+		<polygon class="st1" points="40.1,31.9 31.1,31.9 26.6,39.7 31.1,47.5 40.1,47.5 44.6,39.7 		"/>
+	</g>
+	<g>
+		<polygon class="st1" points="23.5,22.2 14.5,22.2 10,30 14.5,37.8 23.5,37.8 28,30 		"/>
+	</g>
+	<g>
+		<polygon class="st1" points="40.1,12.5 31.1,12.5 26.6,20.3 31.1,28.1 40.1,28.1 44.6,20.3 		"/>
+	</g>
+</g>
+</svg>

--- a/pkg/virtual-clusters/components/CruK3KCluster.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster.vue
@@ -44,6 +44,21 @@ const defaultCluster = {
   }
 };
 
+/**
+ * provisioning.cattle.io.cluster default annotations
+ *
+ * also set before creation:
+ * 'ui.rancher/parent-cluster' - host cluster's norman cluster id
+ * 'ui.rancher/parent-cluster-display' - host cluster provisioning cluster displayName model property
+ * 'ui.rancher/k3k-namespace'  - namespace/id of the k3k cluster in the host cluster
+ */
+const defaultAnnotations = {
+  // prevent k3s-upgrade-controller from running: this will be managed by k3k
+  'rancher.io/imported-cluster-version-management': 'false',
+  // display machine provider in cluster mgmt list
+  'ui.rancher/provider':                            'k3k'
+};
+
 export default {
   emites: ['update:value'],
 
@@ -280,9 +295,8 @@ export default {
 
           // Add annotations so the ui knows the imported cluster is a virtual cluster, and which is its parent cluster
           this.value.metadata = this.value.metadata || {};
-          this.value.metadata.annotations = this.value.metadata.annotations || {};
+          this.value.metadata.annotations = { ...defaultAnnotations };
 
-          this.value.metadata.annotations['ui.rancher/provider'] = 'k3k';
           this.value.metadata.annotations['ui.rancher/parent-cluster'] = clusterId;
 
           this.value.metadata.annotations['ui.rancher/parent-cluster-display'] = parentProvCluster.displayName || parentProvCluster.name;

--- a/pkg/virtual-clusters/components/CruK3KCluster.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster.vue
@@ -35,7 +35,7 @@ const defaultCluster = {
   kind:       'Cluster',
   metadata:   { name: '' },
   spec:       {
-    mode:        'virtual',
+    mode:        'shared',
     agents:      0,
     persistence: {
       storageRequestSize: '1G', type: 'dynamic', storageClassName: 'local-path'

--- a/pkg/virtual-clusters/components/HostCluster.vue
+++ b/pkg/virtual-clusters/components/HostCluster.vue
@@ -97,6 +97,7 @@ export default {
 
         this.k3kInstalled = true;
       } catch (err) {
+        this.didInstallK3k = false;
         this.k3kInstalled = false;
       }
     },

--- a/pkg/virtual-clusters/index.ts
+++ b/pkg/virtual-clusters/index.ts
@@ -19,6 +19,9 @@ export default function(plugin: IPlugin): void {
   plugin.addProduct(require('./product'));
 
 
-    // Register custom provisioner object
-    plugin.register('provisioner', k3kProvisioner.ID, k3kProvisioner);
+  // Register custom provisioner object
+  plugin.register('provisioner', k3kProvisioner.ID, k3kProvisioner);
+
+  // Built-in icon
+  plugin.metadata.icon = require('./assets/icon-virtual-clusters.svg');
 }

--- a/pkg/virtual-clusters/package.json
+++ b/pkg/virtual-clusters/package.json
@@ -1,12 +1,13 @@
 {
   "name": "virtual-clusters",
   "description": "Virtual cluster provisioning using K3K",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/display-name": "Virtual Clusters",
-      "catalog.cattle.io/ui-extensions-version": ">= 3.0.2-rc.5"
+      "catalog.cattle.io/ui-extensions-version": ">= 3.0.2-rc.5",
+      "catalog.cattle.io/experimental": "true"
     }
   },
   "scripts": {},

--- a/pkg/virtual-clusters/provisioner.ts
+++ b/pkg/virtual-clusters/provisioner.ts
@@ -14,6 +14,10 @@ export class k3kProvisioner implements IClusterProvisioner {
   //   mapDriver(this.id, 'k3k' );
   // }
 
+  get icon(): any {
+    return require('./assets/icon-virtual-clusters.svg');
+  }
+
   get id(): string {
     return k3kProvisioner.ID;
   }


### PR DESCRIPTION
- bump to version 0.1.1
- add 'experimental' annotation
- adds a new annotation, see https://github.com/rancher/dashboard/issues/13069
    imported-cluster-version-management: false 
- adds virtual cluster icon
- improves k3k installation retry logic
- default cluster configuration uses 'shared' mode