### PR TITLE
add workflow to build catalog image on release

### DIFF
--- a/.github/workflows/build--extension-catalog.yml
+++ b/.github/workflows/build--extension-catalog.yml
@@ -1,0 +1,24 @@
+name: Build and Release Extension Catalog
+
+on:
+  workflow_dispatch:
+  release:  
+    types: [prereleased, released]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./
+
+jobs:
+  build-extension-catalog:
+    uses: rancher/dashboard/.github/workflows/build-extension-catalog.yml@master
+    permissions:
+      actions: write
+      contents: read
+      packages: write
+    with:
+      registry_target: ghcr.io
+      registry_user: ${{ github.actor }}
+    secrets: 
+      registry_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow to run a @rancher/shell script that will build the extension as a container image and publish it to the  github registry