### PR TITLE
Update the k3k install method to use the chart url instead of k3k repo

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/HostCluster.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/HostCluster.vue
@@ -113,10 +113,7 @@ export default {
         apiVersion: 'catalog.cattle.io/v1',
         kind:       'ClusterRepo',
         metadata:   { name: 'k3k' },
-        spec:       {
-          gitBranch: 'main',
-          gitRepo:   'https://github.com/rancher/k3k.git'
-        }
+        spec:       { url: 'https://rancher.github.io/k3k' }
       };
 
       const cluster = this.parentCluster;


### PR DESCRIPTION
https://github.com/rancher/virtual-clusters-ui/issues/29