### PR TITLE
fix cluster badge customization and install retry logic

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/HostCluster.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/HostCluster.vue
@@ -210,6 +210,7 @@ export default {
             if (res._status === 201) {
               this.k3kInstalled = true;
               this.didInstallK3k = true;
+              break;
             }
           } catch (err) {
             if (installTries >= INSTALL_MAX_TRIES) {

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -24,6 +24,7 @@ import FormValidation from '@shell/mixins/form-validation';
 import { _CREATE } from '@shell/config/query-params';
 import { allHash } from '@shell/utils/promise';
 import { saferDump } from '@shell/utils/create-yaml';
+import { CLUSTER_BADGE } from '@shell/config/labels-annotations';
 
 import { K3K } from '../../types';
 import HostCluster from './HostCluster.vue';
@@ -32,6 +33,7 @@ import Storage from './Storage.vue';
 
 import importConfigMapTemplate from '../../resources/import-configmap.json';
 import importJobTemplate from '../../resources/import-job.json';
+import merge from 'lodash/merge';
 
 const defaultCluster = {
   type:       K3K.CLUSTER,
@@ -169,6 +171,28 @@ export default {
         this.fvFormRuleSets.splice(this.fvFormRuleSets.findIndex((r) => r.path === 'spec.tlsSANs'), 1);
       }
     },
+
+    clusterBadgeAbbreviation: {
+      immediate: true,
+      handler(neu) {
+        if (!neu) {
+          return;
+        }
+
+        if (Object.keys(neu.badge).length <= 0) {
+          return;
+        }
+
+        const obj = {
+          [CLUSTER_BADGE.ICON_TEXT]: neu.badge.iconText, [CLUSTER_BADGE.COLOR]: neu.badge.color, [CLUSTER_BADGE.TEXT]: neu.badge.text
+        };
+
+        this.value.metadata.annotations = {
+          ...this.value.metadata.annotations,
+          ...obj
+        };
+      }
+    },
   },
 
   data() {
@@ -191,7 +215,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters({ t: 'i18n/withFallback' }),
+    ...mapGetters({ t: 'i18n/withFallback', clusterBadgeAbbreviation: 'customisation/getPreviewCluster' }),
 
     canManageMembers() {
       return canViewClusterMembershipEditor(this.$store);
@@ -313,7 +337,7 @@ export default {
 
           // Add annotations so the ui knows the imported cluster is a virtual cluster, and which is its parent cluster
           this.value.metadata = this.value.metadata || {};
-          this.value.metadata.annotations = { ...defaultAnnotations };
+          merge(this.value.metadata.annotations, defaultAnnotations);
 
           this.value.metadata.annotations['ui.rancher/parent-cluster'] = clusterId;
 


### PR DESCRIPTION
Fixes https://github.com/rancher/virtual-clusters-ui/issues/31

The cluster badge appearance customizer was not wired in correctly. During cluster creation, the popup used to customize the badge stores the information in a vuex store and the consuming component needs to update annotations accordingly. (in other contexts the popup modifies a cluster object) I've added a watcher that mirrors how this component is handled in rke2 provisioning.




I also noticed the request to install k3k runs multiple times even if the first succeeds. I think this is related to vue reactivity in some way, where the component property being used to terminate re-tries isn't updated in time to actually stop them? Adding `break` works. 