### PR TITLE
v1alpha1->v1beta1

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -36,7 +36,7 @@ import merge from 'lodash/merge';
 
 const defaultCluster = {
   type:       K3K.CLUSTER,
-  apiVersion: 'k3k.io/v1alpha1',
+  apiVersion: 'k3k.io/v1beta1',
   kind:       'Cluster',
   metadata:   { name: '' },
   spec:       {


### PR DESCRIPTION
k3k CRDs have been updated from `1valpha1` to `v1beta1`   https://github.com/rancher/k3k/pull/505