### PR TITLE
1.0.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-clusters",
-  "version": "0.1.3",
+  "version": "1.0.0-rc1",
   "private": false,
   "engines": {
     "node": ">=20.0.0"

--- a/pkg/virtual-clusters/package.json
+++ b/pkg/virtual-clusters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "virtual-clusters",
   "description": "Virtual cluster provisioning using K3K",
-  "version": "0.1.3",
+  "version": "1.0.0-rc1",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
note if you use 'developer load' to test this one, two vc ui cards will appear in the extensions page. This appears to be a bug in how the developer load function parses extension names when there are multiple hyphens. I've run the build+publish script locally and pushed assets to my fork to properly load this and ensure that bug is specific to developer load.