### PR TITLE
use prime registry to install k3k

### DIFF
--- a/pkg/virtual-clusters/utils/k3kInstalled.js
+++ b/pkg/virtual-clusters/utils/k3kInstalled.js
@@ -1,10 +1,10 @@
 import { CATALOG } from '@shell/config/types';
 
-export const K3K_CHART_NAME = 'k3k';
+export const K3K_CHART_NAME = 'suse-virtual-cluster-engine';
 export const K3K_CHART_NAMESPACE = 'k3k-system';
 
-export const K3K_REPO_NAME = 'k3k';
-export const K3K_REPO_URL = 'https://rancher.github.io/k3k';
+export const K3K_REPO_NAME = 'suse-virtual-cluster-engine';
+export const K3K_REPO_URL = 'oci://registry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine';
 
 /**
  * This function retrieves the count resource for the target cluster and returns true if there is at least one catalog.cattle.io.app in the k3k-system namespace


### PR DESCRIPTION
#60 


This PR updates the "install k3k" button to install k3k from the prime registry. I suggest testing both the install k3k button in cluster explorer and the install k3k button in the cluster creation page. There is little chance of regression in any area other than the "Install K3k" button.