### PR TITLE
rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-clusters",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "private": false,
   "engines": {
     "node": ">=20.0.0"

--- a/pkg/virtual-clusters/package.json
+++ b/pkg/virtual-clusters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "virtual-clusters",
   "description": "Virtual cluster provisioning using K3K (Prime only)",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
I tested this by publishing it to my own fork. To test, you can add the following repository to your local cluster then navigate to the extensions page and install virtual clusters `1.0.0-rc2`


```
apiVersion: catalog.cattle.io/v1
kind: ClusterRepo
metadata:
  name: vc-mantis
spec:
  enabled: true
  url: https://mantis-toboggan-md.github.io/virtual-clusters-ui
```