### PR TITLE
fix link to cluster management in the local clusters k3k landing page

### DIFF
--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -204,7 +204,7 @@ k3k:
     subtitle: Lightweight, fully isolated Kubernetes environments running inside your cluster
     description: Virtual clusters (powered by K3k) let you create self-service, isolated Kubernetes environments without the overhead of managing full clusters.
     prime: The virtual clusters UI extension is only available in Rancher Prime.
-    local: Installing k3k in the local Rancher cluster is not recommended. Navigate to <a href='/c/_/manager' >Cluster Management</a> to import and existing cluster or provision a new one.
+    local: Installing k3k in the local Rancher cluster is not recommended. Navigate to <a href="{managerUrl}">Cluster Management</a> to import and existing cluster or provision a new one.
     steps:
       title: 'Quick guide:'
       step1:

--- a/pkg/virtual-clusters/pages/index.vue
+++ b/pkg/virtual-clusters/pages/index.vue
@@ -6,6 +6,7 @@ import InstallK3k from '../components/InstallK3k.vue';
 import { K3K_CHART_NAMESPACE, K3K_CHART_NAME, verifyK3kIsInstalled } from '../utils/k3kInstalled';
 import Loading from '@shell/components/Loading';
 import { isRancherPrime } from '@shell/config/version';
+import { NAME } from '@shell/config/product/manager';
 
 export default {
   name: 'K3kExplorerLandingPage',
@@ -53,7 +54,14 @@ export default {
       chartName:          K3K_CHART_NAME,
       targetNamespace:    K3K_CHART_NAMESPACE,
       currentProvCluster: null,
-      k3kInstalled:       false // fetch will redirect away from this page if k3k is already installed. This variable tracks if k3k has been installed using the button on this page
+      k3kInstalled:       false, // fetch will redirect away from this page if k3k is already installed. This variable tracks if k3k has been installed using the button on this page
+      managerUrl:                      this.$router.resolve({
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  NAME,
+          resource: CAPI.RANCHER_CLUSTER
+        }
+      }).href,
     };
   },
 
@@ -82,12 +90,10 @@ export default {
     <div v-if="!isPrime">
       {{ t('k3k.landingPage.prime') }}
     </div>
-    <div v-else-if="isLocal">
-      <t
-        k="k3k.landingPage.local"
-        raw
-      />
-    </div>
+    <div
+      v-else-if="isLocal"
+      v-clean-html="t('k3k.landingPage.local', { managerUrl }, true)"
+    />
     <div v-else>
       <div class="mb-20">
         {{ t('k3k.landingPage.description') }}


### PR DESCRIPTION
Fixes https://github.com/rancher/virtual-clusters-ui/issues/62


### validating this PR
#62 cannot be reproduced when running the extension locally so testing this PR must involve building and installing the extension. Pull the PR and run the following: 

`yarn && yarn build-pkg virtual-clusters-ui && yarn serve-pkgs`

Copy the URL outputted by that command. Open rancher dashboard and navigate to the extensions page. Click the three-dot menu and select 'developer load' -- if you don't see that option, you must navigate to user prefs and enable 'use extension developer features'.

Paste the URL from earlier into the modal. Check the box to create a custom resource to persist the extension.

Reload the UI and navigate tot he local cluster explorer. There should be a new nav item Virtual Clusters. Click it. The landing page should show a message advising against installing k3k, and linking to cluster management. Verify that the link to cluster management works.

Note: there's an existing issue dev-loading extensions with a hyphen in the version, where the card is shown twice or not shown at all depending on rancher version, https://github.com/rancher/dashboard/issues/15858