### PR TITLE
Add Resource Synchronization to cluster creation

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/Networking.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/Networking.vue
@@ -179,9 +179,9 @@ export default {
           :val="exposeModes.NONE"
         >
           <template #label>
-            <h4>
+            <h3>
               {{ t('k3k.expose.notExposed.label') }}
-            </h4>
+            </h3>
           </template>
         </RadioButton>
       </div>
@@ -194,9 +194,9 @@ export default {
           :val="exposeModes.INGRESS"
         >
           <template #label>
-            <h4>
+            <h3>
               {{ t('k3k.expose.ingress.label') }}
-            </h4>
+            </h3>
           </template>
         </RadioButton>
       </div>
@@ -232,9 +232,9 @@ export default {
           :read-allowed="false"
         >
           <template #title>
-            <h4 class="mb-0">
+            <h3 class="mb-0">
               {{ t('k3k.expose.ingress.annotations.label') }}
-            </h4>
+            </h3>
           </template>
         </KeyValue>
       </div>
@@ -248,9 +248,9 @@ export default {
           :val="exposeModes.LOAD_BALANCER"
         >
           <template #label>
-            <h4 class="mb-5">
+            <h3 class="mb-5">
               {{ t('k3k.expose.loadbalancer.label') }}
-            </h4>
+            </h3>
             <t
               class="text-label"
               raw
@@ -292,9 +292,9 @@ export default {
           :val="exposeModes.NODE_PORT"
         >
           <template #label>
-            <h4 class="mb-5">
+            <h3 class="mb-5">
               {{ t('k3k.expose.nodePort.label') }}
-            </h4>
+            </h3>
             <t
               class="text-label"
               raw

--- a/pkg/virtual-clusters/components/CruK3KCluster/Storage.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/Storage.vue
@@ -149,7 +149,7 @@ export default {
 
 <template>
   <div>
-    <h4>{{ t('k3k.storage.title') }}</h4>
+    <h3>{{ t('k3k.storage.title') }}</h3>
     <Banner
       v-if="storageClassErrors.length"
       color="error"

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -31,6 +31,7 @@ import Networking from './Networking.vue';
 import Storage from './Storage.vue';
 import ClusterPolicy from './ClusterPolicy.vue';
 import Mode from '../Mode.vue';
+import Sync from '../Sync.vue';
 
 import importConfigMapTemplate from '../../resources/import-configmap.json';
 import importJobTemplate from '../../resources/import-job.json';
@@ -49,7 +50,8 @@ const defaultCluster = {
       type:               'dynamic',
     },
     servers:      1,
-    nodeSelector: {}
+    nodeSelector: {},
+    sync:         {}
   }
 };
 
@@ -89,7 +91,8 @@ export default {
     Storage,
     ArrayList,
     ClusterPolicy,
-    Mode
+    Mode,
+    Sync
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -204,9 +207,11 @@ export default {
         if (neu?.spec) {
           this.k3kCluster.spec.mode = neu.spec.allowedMode;
           this.k3kCluster.spec.nodeSelector = neu.spec.defaultNodeSelector || defaultCluster.spec.nodeSelector;
+          this.k3kCluster.spec.sync = neu.spec.sync || defaultCluster.spec.sync;
         } else {
           this.k3kCluster.spec.mode = defaultCluster.spec.mode;
           this.k3kCluster.spec.nodeSelector = defaultCluster.spec.nodeSelector;
+          this.k3kCluster.spec.sync = defaultCluster.spec.sync;
         }
       },
       deep: true
@@ -528,6 +533,10 @@ export default {
             v-model:k3k-mode="k3kCluster.spec.mode"
             :mode="mode"
           />
+          <Sync
+            v-model:sync="k3kCluster.spec.sync"
+            :mode="mode"
+          />
         </template>
         <Storage
           v-model:storage-class-name="k3kCluster.spec.persistence.storageClassName"
@@ -565,9 +574,9 @@ export default {
               :add-label="t('k3k.agents.envVars.addLabel')"
             >
               <template #title>
-                <h4 class="mb-0">
+                <h3 class="mb-0">
                   {{ t('k3k.servers.envVars.title') }}
-                </h4>
+                </h3>
               </template>
             </KeyValue>
           </div>
@@ -583,7 +592,7 @@ export default {
               :add-label="t('k3k.servers.serverArgs.addLabel')"
             >
               <template #title>
-                <h4>{{ t('k3k.servers.serverArgs.label') }}</h4>
+                <h3>{{ t('k3k.servers.serverArgs.label') }}</h3>
               </template>
             </ArrayList>
           </div>
@@ -612,9 +621,9 @@ export default {
               :add-label="t('k3k.agents.envVars.addLabel')"
             >
               <template #title>
-                <h4 class="mb-0">
+                <h3 class="mb-0">
                   {{ t('k3k.agents.envVars.title') }}
-                </h4>
+                </h3>
               </template>
             </KeyValue>
           </div>
@@ -633,7 +642,7 @@ export default {
               :add-label="t('k3k.nodeSelector.addLabel')"
             >
               <template #title>
-                <h4>{{ t('k3k.nodeSelector.label') }}</h4>
+                <h3>{{ t('k3k.nodeSelector.label') }}</h3>
                 <t
                   raw
                   k="k3k.nodeSelector.tooltip"

--- a/pkg/virtual-clusters/components/Mode.vue
+++ b/pkg/virtual-clusters/components/Mode.vue
@@ -56,7 +56,7 @@ export default {
         @update:value="e=>$emit('update:k3kMode', e)"
       >
         <template #label>
-          <h4>{{ t('k3k.mode.label') }}</h4>
+          <h3>{{ t('k3k.mode.label') }}</h3>
           <h5 class="text-muted">
             {{ t('k3k.mode.tooltip') }}
           </h5>

--- a/pkg/virtual-clusters/components/Sync.vue
+++ b/pkg/virtual-clusters/components/Sync.vue
@@ -1,0 +1,86 @@
+<script>
+import { _CREATE } from '@shell/config/query-params';
+import Checkbox from '@components/Form/Checkbox/Checkbox';
+
+export default {
+  name: 'K3kResourceSync',
+
+  emits: ['update:sync'],
+
+  components: { Checkbox },
+
+  props: {
+    mode: {
+      type:    String,
+      default: _CREATE
+    },
+
+    sync: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+
+  computed: {
+    ingressesEnabled: {
+      get() {
+        return this.sync?.ingresses?.enabled || false;
+      },
+      set(neu) {
+        const out = { ...this.sync };
+
+        if (!out.ingresses) {
+          out.ingresses = {};
+        }
+        out.ingresses.enabled = neu;
+        this.$emit('update:sync', out );
+      }
+    },
+
+    priorityClassesEnabled: {
+      get() {
+        return this.sync?.priorityClasses?.enabled || false;
+      },
+      set(neu) {
+        const out = { ...this.sync };
+
+        if (!out.priorityClasses) {
+          out.priorityClasses = {};
+        }
+        out.priorityClasses.enabled = neu;
+
+        this.$emit('update:sync', out );
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="row mb-10">
+    <div class="col span-12">
+      <h3>{{ t('k3k.policy.synchronization.label') }}</h3>
+      <t
+        class="text-muted"
+        k="k3k.policy.synchronization.tooltip"
+        raw
+      />
+    </div>
+  </div>
+  <div class="row mb-20">
+    <div class="col span-6 vertical-checkboxes">
+      <Checkbox
+        v-model:value="ingressesEnabled"
+        :mode="mode"
+        :label="t('k3k.policy.synchronization.ingressCheckbox')"
+      />
+      <Checkbox
+        v-model:value="priorityClassesEnabled"
+        :mode="mode"
+        :label="t('k3k.policy.synchronization.priorityClassCheckbox')"
+      />
+    </div>
+  </div>
+</template>

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
@@ -2,7 +2,6 @@
 import CruResource from '@shell/components/CruResource';
 import Loading from '@shell/components/Loading';
 import Labels from '@shell/components/form/Labels';
-import Mode from '../../components/Mode.vue';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -14,12 +13,15 @@ import KeyValue from '@shell/components/form/KeyValue.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import Checkbox from '@components/Form/Checkbox/Checkbox';
 import { exceptionToErrorsArray } from '@shell/utils/error';
-import Quota from './Quota.vue';
 import { clear } from '@shell/utils/array';
 import { Banner } from '@rancher/components';
 
 import Projects from './Projects.vue';
 import { ANNOTATIONS } from '../../types';
+import Mode from '../../components/Mode.vue';
+import Sync from '../../components/Sync.vue';
+import Quota from './Quota.vue';
+import isEmpty from 'lodash/isEmpty';
 
 const CONTAINER_LIMIT_TYPE = 'container';
 
@@ -42,7 +44,8 @@ export default {
     LabeledSelect,
     Projects,
     Checkbox,
-    Banner
+    Banner,
+    Sync
   },
 
   async fetch() {
@@ -140,6 +143,19 @@ export default {
           delete this.value.spec.podSecurityAdmissionLevel;
         } else {
           this.value.spec.podSecurityAdmissionLevel = neu;
+        }
+      }
+    },
+
+    sync: {
+      get() {
+        return this.value?.spec?.sync || {};
+      },
+      set(neu) {
+        if (neu && !isEmpty(neu)) {
+          this.value.spec.sync = neu;
+        } else {
+          delete this.value.spec.sync;
         }
       }
     },
@@ -303,7 +319,7 @@ export default {
               :add-label="t('k3k.nodeSelector.addLabel')"
             >
               <template #title>
-                <h4>{{ t('k3k.nodeSelector.label') }}</h4>
+                <h3>{{ t('k3k.nodeSelector.label') }}</h3>
                 <t
                   class="text-muted"
                   raw
@@ -365,33 +381,10 @@ export default {
             />
           </div>
         </div>
-
-        <div class="row mb-10">
-          <div class="col span-12">
-            <h3>{{ t('k3k.policy.synchronization.label') }}</h3>
-            <t
-              class="text-muted"
-              k="k3k.policy.synchronization.tooltip"
-              raw
-            />
-          </div>
-        </div>
-        <div class="row mb-20">
-          <div class="col span-6 vertical-checkboxes">
-            <Checkbox
-              :value="value?.spec?.sync?.ingresses?.enabled"
-              :mode="mode"
-              :label="t('k3k.policy.synchronization.ingressCheckbox')"
-              @update:value="e=>updateSync('ingresses', e)"
-            />
-            <Checkbox
-              :value="value?.spec?.sync?.priorityClasses?.enabled"
-              :mode="mode"
-              :label="t('k3k.policy.synchronization.priorityClassCheckbox')"
-              @update:value="e=>updateSync('priorityClasses', e)"
-            />
-          </div>
-        </div>
+        <Sync
+          v-model:sync="sync"
+          :mode="mode"
+        />
       </Tab>
       <Tab
         :weight="1"

--- a/pkg/virtual-clusters/index.ts
+++ b/pkg/virtual-clusters/index.ts
@@ -5,6 +5,7 @@ import { VClusterModelExtension } from './model-extension/provisioning.cattle.io
 import virtualClusterRouting from './routes'
 
 
+
 // Init the package
 export default function(plugin: IPlugin): void {
   // Auto-import model, detail, edit from the folders
@@ -28,5 +29,5 @@ export default function(plugin: IPlugin): void {
 
   // Built-in icon
   plugin.metadata.icon = require('./assets/icon-k3k.svg');
-
+  
 }


### PR DESCRIPTION
https://github.com/rancher/virtual-clusters-ui/issues/58

- add a resource synchronization section to virtual cluster creation
- cluster creation's resource synchronization section should only be shown when no policy is selected
- when a policy is selected during cluster creation, its resource synchronization configuration should be copied into the k3k cluster spec
- the resource synchronization section in cluster policy creation should be unchanged


### Testing
1. Open the browser's network tab to watch what data is sent during cluster creation.
2. Navigate to the cluster explorer of a downstream cluster with k3k installed and select 'policies' from under the virtual clusters nav item.
3. Create a virtual cluster policy, and in the 'advanced' section, check the ingresses and priorityclasses checkboxes. Assign a project to the policy as well (only projects with namespaces can be assigned)
4. Create another policy and do not check the ingress nor priorityclasses checkboxes. Assign a project to it as well.
5. Navigate to cluster management cluster list view, click 'create', and select k3k
6. Select the downstream cluster you created policies in.
7. Select the policy with ingresses and priorityclasses checked, name your cluster, and click create.
8. Look in the network tab and verify the POST request to create the k3k cluster contains `spec.sync.ingresses.enabled: true` and `spec.sync.priorityClasses.enabled: true`. Verify that the cluster provisions without error.
9. Also create a virtual cluster using the policy from step 4. Verify that the POST request to create the cluster does not specify `spec.sync.ingresses.enabled` nor `spec.sync.priorityClasses.enabled`
10. Create a virtual cluster with "None" selected in the policy dropdown. 
11. Verify that when the ingress and priorityclass checkboxes are checked during cluster creation, `spec.sync.ingresses.enabled` and `spec.sync.priorityClasses.enabled` are configured in the POST request to create the k3k cluster.

### Screenshots
This PR also converts some h4's to h3's for consistency. Before/after screenshots of that below
<details>
<img width="1769" height="1445" alt="Screenshot 2025-11-10 at 11 24 07 AM" src="https://github.com/user-attachments/assets/01caba37-ec35-41f5-bad4-4abde0e665bf" />
<img width="1494" height="1444" alt="Screenshot 2025-11-10 at 11 26 00 AM" src="https://github.com/user-attachments/assets/a6d1b716-1ebb-49a2-805d-eeeeb5298a5c" />



<img width="1764" height="1442" alt="Screenshot 2025-11-10 at 11 24 19 AM" src="https://github.com/user-attachments/assets/85893625-f529-451c-8c52-7f86aff5a4ab" />

<img width="1499" height="1447" alt="Screenshot 2025-11-10 at 11 26 14 AM" src="https://github.com/user-attachments/assets/7e0fcf4a-f531-4957-a921-665da59ca7b8" />





<img width="1768" height="1446" alt="Screenshot 2025-11-10 at 11 24 24 AM" src="https://github.com/user-attachments/assets/ec9ceea5-870f-4209-93a2-aa6bca1eabe6" />
<img width="1497" height="1443" alt="Screenshot 2025-11-10 at 11 27 02 AM" src="https://github.com/user-attachments/assets/e4dcd34f-a7df-40b4-a3a4-79636128f4ae" />





<img width="1766" height="1445" alt="Screenshot 2025-11-10 at 11 24 30 AM" src="https://github.com/user-attachments/assets/21a00ce6-5f1c-4049-98b5-eba13d40ab13" />
<img width="1498" height="1449" alt="Screenshot 2025-11-10 at 11 27 11 AM" src="https://github.com/user-attachments/assets/c78807ab-0d51-40f7-b324-195b375f3b71" />





<img width="1773" height="1445" alt="Screenshot 2025-11-10 at 11 23 59 AM" src="https://github.com/user-attachments/assets/357a5115-1f86-4619-9b17-36888637b843" />
<img width="1434" height="1451" alt="Screenshot 2025-11-10 at 11 27 59 AM" src="https://github.com/user-attachments/assets/ed83ffa6-0571-4436-b813-731913acebd8" />



</details>