### PR TITLE
Fixed error shown when policy has partially assigned namespaces

### DIFF
--- a/pkg/virtual-clusters/models/k3k.io.virtualclusterpolicy.js
+++ b/pkg/virtual-clusters/models/k3k.io.virtualclusterpolicy.js
@@ -75,8 +75,12 @@ export default class VirtualClusterPolicy extends SteveModel {
 
   get stateObj() {
     const defaultStateObj = super.stateObj;
+    const partialError = !this.hasPartiallyAssignedProjects ? {} : {
+      error:   true,
+      message: this.stateDescription
+    };
 
-    return { ...defaultStateObj, error: this.hasPartiallyAssignedProjects || defaultStateObj?.error };
+    return { ...defaultStateObj, ...partialError };
   }
 
   get stateColor() {


### PR DESCRIPTION
Fixes #71 
Model's stateObj is used for both the description in Virtual Cluster Policies and the detail page's masthead. 
Adjusted stateObj's message to have a meaningful error. There is some error duplication going on, but I don't think it's possible to fix without modifying how shell uses stateObj