### PR TITLE
Fix error loading virtualclusters product on reload

### DIFF
--- a/pkg/virtual-clusters/config/k3k-explorer-product.ts
+++ b/pkg/virtual-clusters/config/k3k-explorer-product.ts
@@ -13,8 +13,7 @@ export async function init($plugin:any, store:any) {
     basicType,
     headers
   } = $plugin.DSL(store, NAME);
-    await versions.fetch({ store: store });
-  
+
     if(isRancherPrime()){
         product({
           inStore:             'cluster',

--- a/pkg/virtual-clusters/config/k3k-management-product.ts
+++ b/pkg/virtual-clusters/config/k3k-management-product.ts
@@ -5,7 +5,6 @@ export async function init($plugin:any, store:any) {
   const {
     configureType,
   } = $plugin.DSL(store, 'manager');
-    await versions.fetch({ store: store });
 
     if(isRancherPrime()){
         configureType('provisioning.cattle.io.cluster', {

--- a/pkg/virtual-clusters/index.ts
+++ b/pkg/virtual-clusters/index.ts
@@ -54,10 +54,14 @@ export default function(plugin: IPlugin): void {
   // Built-in icon
   plugin.metadata.icon = require('./assets/icon-k3k.svg');
 
-  plugin.addNavHooks(undefined, undefined, undefined, async(store: any)=>{
-    try{
-      await versions.fetch({ store: store });
+  // used to compute isRancherPrime
+  // this is used in onEnter to ensure prime data is loaded before isRancherPrime is called in product config
+  // the rest of the role-creation logic runs on login instead of on enter to minimize performance impact
+  const fetchVersionData = async (store: any)=>await versions.fetch({ store: store });
 
+  plugin.addNavHooks(fetchVersionData, undefined, undefined, async(store: any)=>{
+    try{
+      await fetchVersionData(store)
       if(isRancherPrime()){
         await Promise.all([store.dispatch('management/loadSchemas'), store.dispatch('rancher/loadSchemas')])
         const roleSchema = store.getters['management/byId'](SCHEMA, MANAGEMENT.ROLE_TEMPLATE )


### PR DESCRIPTION
#90 

This PR updates the code used to determine if the Rancher instance is Prime before loading the virtual cluster product. I moved the request to fetch version data into a nav hook that runs before routes added by this extension are loaded. 

I suggest building the extension locally and using 'developer load' since this area previously had issues that only cropped up when the extension was built. The following areas should be checked:
- In a Rancher prime instance, navigate to the virtual policy list view and refresh the page. No errors should be shown
- In a Rancher prime instance, navigate to cluster management cluster list -> create and refresh the page. The k3k card should still be shown.
- In a community Rancher instance, navigate to the cluster explorer and refresh the page. The virtual cluster product should not appear in the nav.
- In a community Rancher instance, manually nav to  `.../dashboard/c/local/virtualclusters`. An error about not finding the product should be shown
- In a community Rancher instance, navigate to cluster management cluster list -> create and refresh the page. The k3k card should not be shown. 
