### PR TITLE
assign namespaces to policies before switching to yaml editor view

### DIFF
--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -84,7 +84,6 @@ k3k:
       headers:
         resourceType: Resource Type
         clusterSetLimit: Cluster Set Limit
-        vcSetLimit: Virtual Cluster Set Limit
     listView:
       modeHeader: Mode
       projectHeader: Assigned Projects
@@ -105,6 +104,9 @@ k3k:
           one {The selected policies are collectively applied to one virtual cluster. Deleting the policies now will remove resource constraints from that cluster.}
           other {The selected policies are currently applied to {count} virtual clusters. Deleting the policies now will remove resource constraints from those clusters.}
         }
+    editYamlModal:
+      title: Assign Projects to Virtual Cluster Policy
+      body: Virtual cluster polciies cannot be assigned to projects by modifying the policy YAML directly. Namespaces within the projects selected in the policy creation UI will be annotated to assign them to the policy before proceeding.
   targetNamespace:
     label: Target Namespace
   hostCluster:


### PR DESCRIPTION
#98 

Policies can't be assigned from the yaml view, so I copied behavior in rke2/k3s provisioning. The UI will attempt to assign namespaces to the policy before switching to the yaml view. Users are shown a confirmation modal. 

If users click create -> assign project -> view as yaml -> cancel namespaces will be annotated but the annotation is not functional unless a policy exists so I think this is fine

<img width="660" height="202" alt="Screenshot 2026-01-27 at 6 33 13 AM" src="https://github.com/user-attachments/assets/353a020b-035d-41c5-bd22-8323353181a1" />


successfully assign > 200 ns

https://github.com/user-attachments/assets/4c54743d-5213-416f-b182-cd459c5d9128

(fake) error assigning > 200 ns

https://github.com/user-attachments/assets/408e0cb5-4444-4654-86f3-83faf5c7b6b3

