### PR TITLE
fix container limit type for virtualclusterpolicy limitRange

### DIFF
--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
@@ -23,7 +23,7 @@ import Quota from './Quota.vue';
 import isEmpty from 'lodash/isEmpty';
 import { MODES } from '../../utils/shared';
 
-const CONTAINER_LIMIT_TYPE = 'container';
+const CONTAINER_LIMIT_TYPE = 'Container';
 
 export default {
   name: 'CRUClusterPolicy',


### PR DESCRIPTION
Fix a small bug with `VirtualClusterPolicy` `limits` object.
According to the Kubernetes [doc](https://kubernetes.io/docs/concepts/policy/limit-range/), the expected value for `type` is `Container`

This fix allow the creation of the `LimitRange` via the `VCP`

Issue observed in `k3k` controller pod:
```
2026-02-12T10:31:51.922Z	ERROR	Reconciler error	{"controller": "virtualclusterpolicy", "controllerGroup": "k3k.io", "controllerKind": "VirtualClusterPolicy", "VirtualClusterPolicy": {"name":"testp"}, "namespace": "", "name": "testp", "reconcileID": "dae5c45e-71a4-4919-a438-b71a1f933aec", "error": "LimitRange \"k3k-testp\" is invalid: spec.limits[0].type: Invalid value: \"container\": must be a standard limit type or fully qualified"}
```