### PR TITLE
fix gpu limitrange key

### DIFF
--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
@@ -77,7 +77,7 @@ export default {
         const { max = {}, defaultRequest = {} } = limit;
 
         return {
-          limitsCpu: max.cpu, limitsMemory: max.memory, limitsGpu: max.gpu, requestsCpu: defaultRequest.cpu, requestsMemory: defaultRequest.memory
+          limitsCpu: max.cpu, limitsMemory: max.memory, limitsGpu: max['nvidia.com/gpu'], requestsCpu: defaultRequest.cpu, requestsMemory: defaultRequest.memory
         };
       },
 
@@ -112,7 +112,7 @@ export default {
           neu.defaultRequest.memory = requestsMemory;
         }
         if (limitsGpu !== undefined) {
-          neu.max.gpu = limitsGpu;
+          neu.max['nvidia.com/gpu'] = limitsGpu;
         }
         this.value.spec.limit.limits = [neu];
       }


### PR DESCRIPTION
To test, create a virtual cluster policy with default container resource limits specified. Ensure the policy is assigned to at least one project with at least one namespace. Validate that after the policy is created, a LimitRange is created in each assigned namespace. The LimitRange should include the container default resource limits specified in the policy.

<img width="1614" height="641" alt="Screenshot 2026-02-12 at 9 42 34 AM" src="https://github.com/user-attachments/assets/9f8349f6-1dbe-456f-a99d-5104fc6c036a" />

<img width="1898" height="865" alt="Screenshot 2026-02-12 at 9 42 57 AM" src="https://github.com/user-attachments/assets/25ed4750-7349-4967-b4de-534ac4e19e59" />
