### PR TITLE
Fixed Quotas for some resource types being empty

### DIFF
--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/Quota.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/Quota.vue
@@ -30,7 +30,8 @@ export default {
   },
 
   created() {
-    this.typeValues = Object.keys(this.value);
+    this.typeValues = Object.keys(this.value)
+      .filter((type) => !!this.typeOption(type));
   },
 
   computed: {
@@ -45,6 +46,10 @@ export default {
     updateType(i, type) {
       this.typeValues[i] = type;
       this.$emit('update:value', this.value);
+    },
+
+    typeOption(type) {
+      return this.mappedTypes.find((mappedType) => mappedType.value === type);
     },
 
     remainingTypes(currentType) {
@@ -89,6 +94,7 @@ export default {
           :mode="mode"
           :types="remainingTypes(typeValues[props.i])"
           :type="typeValues[props.i]"
+          :type-option="typeOption(typeValues[props.i])"
           @update="$emit('update:value', value)"
           @type-change="updateType(props.i, $event)"
         />

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
@@ -23,17 +23,16 @@ export default {
       default: ''
     },
 
+    typeOption: {
+      type:    Object,
+      default: null
+    },
+
     value: {
       type:    Object,
       default: () => {
         return {};
       }
-    }
-  },
-
-  computed: {
-    typeOption() {
-      return this.types.find((type) => type.value === this.type);
     }
   },
 
@@ -56,7 +55,6 @@ export default {
 </script>
 <template>
   <div
-    v-if="typeOption"
     class="row"
   >
     <UnabeledSelect

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
@@ -24,8 +24,8 @@ export default {
     },
 
     typeOption: {
-      type:    Object,
-      default: null
+      type:     Object,
+      required: true
     },
 
     value: {

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
@@ -25,7 +25,7 @@ export default {
 
     typeOption: {
       type:     Object,
-      required: true
+      default:  () => ({})
     },
 
     value: {

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/QuotaRow.vue
@@ -1,7 +1,6 @@
 <script>
 import Select from '@shell/components/form/Select';
 import UnitInput from '@shell/components/form/UnitInput';
-import { ROW_COMPUTED } from '@shell/components/form/ResourceQuota/shared';
 
 export default {
   emits: ['type-change', 'update'],
@@ -32,7 +31,11 @@ export default {
     }
   },
 
-  computed: { ...ROW_COMPUTED },
+  computed: {
+    typeOption() {
+      return this.types.find((type) => type.value === this.type);
+    }
+  },
 
   methods: {
     // delete the old type key and tell the parent component to add a new one

--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -216,7 +216,7 @@ k3k:
     subtitle: Lightweight, fully isolated Kubernetes environments running inside your cluster
     description: Virtual clusters (powered by K3k) let you create self-service, isolated Kubernetes environments without the overhead of managing full clusters.
     prime: The virtual clusters UI extension is only available in Rancher Prime.
-    local: Installing k3k in the local Rancher cluster is not recommended. Navigate to <a href="{managerUrl}">Cluster Management</a> to import and existing cluster or provision a new one.
+    local: Installing k3k in the local Rancher cluster is not recommended. Navigate to <a href="{managerUrl}">Cluster Management</a> to import an existing cluster or provision a new one.
     permission: |-
         The K3K helm chart may not be installed on this cluster, or you might not have sufficient permissions.<br/><br/>
         <strong>Requirements</strong><br/><br/>
@@ -269,6 +269,12 @@ typeLabel:
     }
 
 resourceQuota:
+  cpu: CPU
+  memory: Memory
+  pods: Pods
+  cpuPlaceholder: e.g. 2
+  memoryPlaceholder: e.g. 2Gi
+  podsPlaceholder: e.g. 10
   generic:
     countPersistentVolumeClaims: PersistentVolumeClaim Count
     countPods: Pod Count

--- a/pkg/virtual-clusters/utils/quota.js
+++ b/pkg/virtual-clusters/utils/quota.js
@@ -7,6 +7,27 @@ export const GENERIC_QUOTA_TYPES = [
     placeholderKey: 'resourceQuota.projectLimit.unitlessPlaceholder'
   },
   {
+    value:          'cpu',
+    inputExponent:  -1,
+    baseUnitKey:    'suffix.cpus',
+    labelKey:       'resourceQuota.cpu',
+    placeholderKey: 'resourceQuota.cpuPlaceholder'
+  },
+  {
+    value:          'memory',
+    inputExponent:  2,
+    increment:      1024,
+    labelKey:       'resourceQuota.memory',
+    placeholderKey: 'resourceQuota.memoryPlaceholder'
+  },
+  {
+    value:          'pods',
+    inputExponent:  0,
+    baseUnit:       '',
+    labelKey:       'resourceQuota.pods',
+    placeholderKey: 'resourceQuota.podsPlaceholder'
+  },
+  {
     value:          'limits.cpu',
     inputExponent:  -1,
     baseUnitKey:    'suffix.cpus',


### PR DESCRIPTION
Fixes #129 #133 #126
RowComputed has changed between shell versions so some of the quota types were not getting parsed correctly.
When types were not recognized, we still showed the row, but the content was hidden. Added a filter to filter out unsupported rows.
Added a few missing types [(pod, cpu, memory)](https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scope-non-terminating)
Fixed typo in the landing page