### PR TITLE
Fix k3k upgrade banner link; fix topology section in policy drawer

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -125,9 +125,10 @@ export default {
       }
 
       this.openDrawer(PolicyDrawer, '[data-testid="k3k-policy-open-drawer"]', {
-        policy:     drawerPolicy,
-        showHeader: false,
-        width:      '50%'
+        policy:        drawerPolicy,
+        parentCluster: this.hostCluster,
+        showHeader:    false,
+        width:         '50%'
       });
     },
 

--- a/pkg/virtual-clusters/components/K3kVersionBanner.vue
+++ b/pkg/virtual-clusters/components/K3kVersionBanner.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { useStore } from 'vuex';
+import { useRouter } from 'vue-router';
 import { Banner } from '@rancher/components';
 import { verifyK3kVersionMatches } from '../utils/k3kInstalled';
-
-type ParentClusterType = {
-  id?: string
-  mgmt?: {
-    id?: string
-  }
-} | null;
+import type { ParentClusterType } from '../types/k3k';
 
 const props = withDefaults(defineProps<{ parentCluster?: ParentClusterType }>(), { parentCluster: null });
 
 const store = useStore();
+const router = useRouter();
 const showK3kVersionBanner = ref(false);
 
 const targetMgmtId = computed<string | null>(() => {
@@ -27,7 +23,7 @@ const chartsUrl = computed<string | null>(() => {
     return null;
   }
 
-  return `/c/${ targetMgmtId.value }/apps/charts`;
+  return router.resolve({ path: `/c/${ targetMgmtId.value }/apps/charts` }).href;
 });
 
 watch(targetMgmtId, async(neu) => {

--- a/pkg/virtual-clusters/components/K3kVersionBanner.vue
+++ b/pkg/virtual-clusters/components/K3kVersionBanner.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { useStore } from 'vuex';
-import { useRouter } from 'vue-router';
 import { Banner } from '@rancher/components';
 import { verifyK3kVersionMatches } from '../utils/k3kInstalled';
 import type { ParentClusterType } from '../types/k3k';
@@ -9,7 +8,6 @@ import type { ParentClusterType } from '../types/k3k';
 const props = withDefaults(defineProps<{ parentCluster?: ParentClusterType }>(), { parentCluster: null });
 
 const store = useStore();
-const router = useRouter();
 const showK3kVersionBanner = ref(false);
 
 const targetMgmtId = computed<string | null>(() => {
@@ -23,7 +21,12 @@ const chartsUrl = computed<string | null>(() => {
     return null;
   }
 
-  return router.resolve({ path: `/c/${ targetMgmtId.value }/apps/charts` }).href;
+  // can't rely on useRouter() and router.resolve because router isn't always available with how this component is dynamically imported into a drawer in cluster creation
+  const pathname = window.location.pathname;
+  const clusterPathIndex = pathname.indexOf('/c/');
+  const basePath = clusterPathIndex >= 0 ? pathname.slice(0, clusterPathIndex) : '';
+
+  return `${ basePath }/c/${ targetMgmtId.value }/apps/charts`;
 });
 
 watch(targetMgmtId, async(neu) => {

--- a/pkg/virtual-clusters/components/PolicyDrawer.vue
+++ b/pkg/virtual-clusters/components/PolicyDrawer.vue
@@ -6,9 +6,12 @@ import { _VIEW } from '@shell/config/query-params';
 import { useDrawer } from '@shell/composables/drawer';
 
 import PolicyEditor from '../edit/k3k.io.virtualclusterpolicy/index.vue';
-import type { K3kPolicy } from '../types/k3k';
+import type { K3kPolicy, ParentClusterType } from '../types/k3k';
 
-const props = withDefaults(defineProps<{ policy?: K3kPolicy }>(), { policy: () => ({}) });
+const props = withDefaults(defineProps<{ policy?: K3kPolicy, parentCluster?: ParentClusterType }>(), {
+  policy:        () => ({}),
+  parentCluster: null,
+});
 
 const VIEW = _VIEW;
 const store = useStore();
@@ -33,6 +36,7 @@ const closeDrawer = close;
       <PolicyEditor
         :value="policy"
         :mode="VIEW"
+        :parent-cluster="parentCluster"
       />
     </template>
   </Drawer>

--- a/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
+++ b/pkg/virtual-clusters/edit/k3k.io.virtualclusterpolicy/index.vue
@@ -53,11 +53,26 @@ export default {
     KeyValue,
   },
 
+  // provisioning cluster object - needed when the policy form is shown in a drawer during cluster creation
+  props: {
+    parentCluster: {
+      type:    Object,
+      default: null
+    },
+  },
+
   async fetch() {
     if (!this.value.spec) {
       this.value.spec = { allowedMode: MODES.SHARED };
     }
-    const mgmtId = this.$store.getters['currentCluster'].id;
+    const selectedCluster = this.parentCluster || this.$store.getters['currentCluster'];
+    const mgmtId = selectedCluster?.mgmt?.id || selectedCluster?.id;
+
+    if (!mgmtId) {
+      this.supportsTopology = false;
+
+      return;
+    }
 
     try {
       this.supportsTopology = await fieldIsSupported(this.$store, mgmtId, K3K.POLICY, 'spec.defaultServerAffinity');
@@ -263,7 +278,7 @@ export default {
     @finish="saveOverride"
     @error="e=>errors=e"
   >
-    <K3kVersionBanner />
+    <K3kVersionBanner :parent-cluster="parentCluster" />
     <Banner
       v-for="(err, i) in errors"
       :key="i"

--- a/pkg/virtual-clusters/types/k3k.ts
+++ b/pkg/virtual-clusters/types/k3k.ts
@@ -35,3 +35,10 @@ export type K3kPolicy = {
   spec?: K3kPolicySpec;
   setAnnotation?: (keys: string[], value: string) => void; // setAnnotation is defined in resource-class
 } & Record<string, unknown>;
+
+export type ParentClusterType = {
+  id?: string;
+  mgmt?: {
+    id?: string;
+  };
+} | null;


### PR DESCRIPTION
#142 

#143 

#142 is only reproducible when the extension is built so I suggest using developer load to verify this PR.

## Summary
142: Fix how the url to the charts page is constructed

143: Fix  topology and node selector visibility in the virtual cluster policy form when it appears in the cluster provisioning context, where `currentCluster` is not defined.

## Testing
Testing this PR requires installing different versions of k3k, which can't be done using the 'install k3k' button in cluster creation. Instead, add the k3k repository and install k3k from there. 

**Ensure that you install the k3k app into the `k3k-system` namespace. Name the app `suse-virtual-cluster-engine`.**

Add the following cluster repo to the desired host cluster: 

```
apiVersion: catalog.cattle.io/v1
kind: ClusterRepo
metadata:
  name: k3k
spec:
  url: https://rancher.github.io/k3k
```




### Host clusters with k3k < 1.1.0
Create a virtual cluster policy (host cluster cluster explorer)
Go to the virtual cluster creation form and select the host cluster + policy (cluster management)
Use the 'show policy configuration' link to open a drawer and view the policy
Verify that the topology section is not shown
Verify that the upgrade banner is shown, and its link works

### Host clusters with k3k >= 1.1.0
Create a virtual cluster policy with some topology defined
Go to the virtual cluster creation form and select the host cluster + policy
Use the 'show policy configuration' link to open a drawer and view the policy
Verify that the topology tab is shown and populated
Verify that no upgrade banner is shown

### Upgrading k3k
Install k3k 1.0.3 on a host cluster
Create a virtual cluster policy and configure a node selector ('advanced' tab)
Upgrade k3k to 1.1.0
Go to the virtual cluster creation page, select the upgraded host cluster, and select the policy with the node selector
Use the 'show policy configuration' link to open a drawer and view the policy
Verify that the advanced tab includes a warning about using node selectors when topology is an option