### PR TITLE
Fix hardcoded import job image for air-gapped environments

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -19,6 +19,7 @@ import Tabbed from '@shell/components/Tabbed';
 
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor';
 import { CAPI, MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
@@ -42,6 +43,20 @@ import importConfigMapTemplate from '../../resources/import-configmap.json';
 import importJobTemplate from '../../resources/import-job.json';
 import merge from 'lodash/merge';
 import { set } from '@shell/utils/object';
+
+// Pinned fallback for the cluster import job image; used when the
+// 'shell-image' setting is empty. Kept in sync with the rancher/shell
+// version shipped with the minimum supported Rancher release.
+const DEFAULT_IMPORT_JOB_IMAGE = 'rancher/shell:v0.7.0';
+
+// Returns true if the first segment of an image reference is a registry
+// host (contains '.' or ':', or is 'localhost'), mirroring containerd's
+// reference parsing.
+function imageHasRegistry(image) {
+  const firstSegment = image.split('/')[0];
+
+  return firstSegment.includes('.') || firstSegment.includes(':') || firstSegment === 'localhost';
+}
 
 const defaultCluster = {
   type:       K3K.CLUSTER,
@@ -391,6 +406,35 @@ export default {
       }
     },
 
+    // resolve the image used by the import job: honor the 'shell-image'
+    // setting if configured, otherwise fall back to a pinned default, and
+    // prefix with 'system-default-registry' so air-gapped installs pull
+    // from their private registry (same behavior as Rancher's own shell pods)
+    async importJobImage() {
+      let image = DEFAULT_IMPORT_JOB_IMAGE;
+
+      try {
+        const shellImage = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: 'shell-image' });
+
+        if (shellImage?.value) {
+          image = shellImage.value;
+        }
+      } catch {}
+
+      if (!imageHasRegistry(image)) {
+        try {
+          const registrySetting = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.SYSTEM_DEFAULT_REGISTRY });
+          const registry = registrySetting?.value;
+
+          if (registry) {
+            image = `${ registry }/${ image }`;
+          }
+        } catch {}
+      }
+
+      return image;
+    },
+
     // create import cluster command from new prov cluster
     // run a job to generate kubeconfig and run the import command on the virtual cluster
     async importCluster() {
@@ -419,6 +463,7 @@ export default {
       let _importJob = JSON.stringify(importJobTemplate).replaceAll(/K3K_NAME/g, this.value.metadata.name);
 
       _importJob = _importJob.replaceAll(/__url/g, registrationUrl);
+      _importJob = _importJob.replaceAll(/__shell_image/g, await this.importJobImage());
 
       const _importConfigMap = JSON.stringify(importConfigMapTemplate).replaceAll(/K3K_NAME/g, this.value.metadata.name);
 

--- a/pkg/virtual-clusters/resources/import-job.json
+++ b/pkg/virtual-clusters/resources/import-job.json
@@ -11,7 +11,7 @@
           "containers": [
             {
               "name": "import",
-              "image": "rancher/shell:head",
+              "image": "__shell_image",
               "command": [
                 "sh",
                 "/scripts/import.sh"


### PR DESCRIPTION
Fixes #151

## Problem

The cluster import job created by the provisioning UI uses a hardcoded `rancher/shell:head` image ([`resources/import-job.json`](https://github.com/rancher/virtual-clusters-ui/blob/virtual-clusters-1.1.0/pkg/virtual-clusters/resources/import-job.json#L14)). `importCluster()` only substitutes the cluster name and registration URL, so:

- In **air-gapped environments** the job fails with `ImagePullBackOff`: the image ignores the `system-default-registry` setting, and the `head` tag is generally not mirrored into private registries (Rancher's air-gap image lists ship pinned `rancher/shell` versions such as `v0.7.0`).
- The **mutable `head` tag** is not suitable for production: its content changes between pulls, and immutable-tag policies commonly enforced in enterprise registries reject it.

By contrast, Rancher's own shell pods (kubectl shell, helm-operation) correctly resolve to `<system-default-registry>/rancher/shell:<pinned version>`, which is exactly the discrepancy users notice.

## Fix

Resolve the import job image at creation time, mirroring the backend's behavior for shell pods:

1. Use the `shell-image` management setting when configured (admins already use this to override the shell image globally).
2. Otherwise fall back to a pinned `rancher/shell` version instead of `head`.
3. Prefix with `system-default-registry` when the resolved image does not already carry a registry host.

Setting lookups are best-effort: if the user creating the cluster cannot read management settings, the job falls back to the pinned default image.

## Testing

- Air-gapped lab (Rancher v2.14.2, `system-default-registry: harbor.airgap.lab`, downstream RKE2 host cluster, authenticated Harbor): creating a virtual cluster through the UI produces an import job with image `harbor.airgap.lab/rancher/shell:v0.7.0`; the job pulls, completes, and the virtual cluster registers with Rancher:

```
$ kubectl get job import-pr-fix-test -n cattle-fleet-system -o jsonpath='{.spec.template.spec.containers[0].image}{"  succeeded="}{.status.succeeded}{"\n"}'
harbor.airgap.lab/rancher/shell:v0.7.0  succeeded=1
```

- With `shell-image` set to a fully-qualified image: the job uses that image verbatim (no double-prefixing).
- With no settings configured (non-airgapped default): the job uses the pinned `rancher/shell:v0.7.0`.


