### PR TITLE
Allow users to create a new namespace when selecting a target ns

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -2,6 +2,7 @@
 import { _CREATE } from '@shell/config/query-params';
 
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate';
 import { LABELS, K3K } from '../../types';
 import { NAMESPACE } from '@shell/config/types';
 import { Banner } from '@rancher/components';
@@ -25,6 +26,7 @@ export default {
 
   components: {
     LabeledSelect,
+    LabeledSelectWithCreate,
     Banner
   },
 
@@ -78,7 +80,9 @@ export default {
       namespaces:                   [],
       loadingPoliciesAndNamespaces: false,
       namespaceError:               false,
-      policyError:                  false
+      policyError:                  false,
+      namespaceCreating:            false,
+      previousTargetNamespace:      '',
     };
   },
 
@@ -91,19 +95,32 @@ export default {
       }
     },
 
-    policyOptions(neu = []) {
-      const policyOpt = neu.find((p) => !!p?.value ) ;
-
-      if (this.mode === _CREATE) {
-        this.$emit('update:policy', policyOpt?.value || null);
-        this.$emit('update:targetNamespace', '');
+    policyOptions(neu = [], old = []) {
+      if (this.mode !== _CREATE) {
+        return;
       }
+
+      const policyIds = (opts) => opts.map((p) => p?.value?.metadata?.name || '').join('|');
+
+      // We need this check because the policy options get recalculated when new namespace is added
+      if (policyIds(neu) === policyIds(old)) {
+        return;
+      }
+
+      // only preset the policy on create when there's a single unambiguous option
+      const realPolicyOptions = neu.filter((p) => !!p?.value);
+
+      this.$emit('update:policy', realPolicyOptions.length === 1 ? realPolicyOptions[0].value : null);
+      this.$emit('update:targetNamespace', '');
     },
 
     namespaceOptions(neu = []) {
-      if (this.mode === _CREATE && !neu.includes(this.targetNamespace)) {
-        this.$emit('update:targetNamespace', neu[0] || '');
+      if (this.mode !== _CREATE || neu.includes(this.targetNamespace)) {
+        return;
       }
+
+      // when there's no policy selected, let the user pick a namespace explicitly rather than presetting one
+      this.$emit('update:targetNamespace', this.isPolicySelected ? (neu[0] || '') : '');
     },
 
   },
@@ -158,7 +175,6 @@ export default {
 
     async fetchNamespaces() {
       this.namespaceError = false;
-      this.namespaces = [];
       try {
         const res = await this.$store.dispatch('management/request', {
           url:    `/k8s/clusters/${ this.hostClusterId }/v1/${ NAMESPACE }`,
@@ -194,7 +210,37 @@ export default {
       }
     },
 
-    isEmpty
+    isEmpty,
+
+    onNamespaceCreating() {
+      this.previousTargetNamespace = this.targetNamespace;
+      this.namespaceCreating = true;
+    },
+
+    async onNamespaceCreate(name) {
+      this.namespaceCreating = false;
+      try {
+        await this.$store.dispatch('management/request', {
+          url:    `/k8s/clusters/${ this.hostClusterId }/v1/${ NAMESPACE }`,
+          method: 'POST',
+          data:   {
+            apiVersion: 'v1',
+            kind:       'Namespace',
+            metadata:   { name },
+          },
+        });
+        await this.fetchNamespaces();
+        this.$emit('update:targetNamespace', name);
+      } catch (e) {
+        this.namespaceError = true;
+        this.$emit('update:targetNamespace', this.previousTargetNamespace);
+      }
+    },
+
+    cancelCreateNamespace() {
+      this.namespaceCreating = false;
+      this.$emit('update:targetNamespace', this.previousTargetNamespace);
+    },
   },
 
   computed: {
@@ -261,6 +307,9 @@ export default {
 
     showLoadingSpinner() {
       return this.loadingPoliciesAndNamespaces || this.$fetchState.pending;
+    },
+    isPolicySelected() {
+      return this.policy && !isEmpty(this.policy);
     }
   },
 };
@@ -283,7 +332,7 @@ export default {
       class="col span-6"
     >
       <LabeledSelect
-        :value="policy && !isEmpty(policy) ? policy : t('generic.none')"
+        :value="isPolicySelected ? policy : t('generic.none')"
         :loading="showLoadingSpinner"
         :disabled="!hostClusterId || !k3kInstalled || !isCreate"
         :mode="mode"
@@ -297,7 +346,7 @@ export default {
         class="nonepolicy-warning text-deemphasized"
       ><i class="icon icon-warning" />{{ t('k3k.policy.noneWarning') }}</span>
       <button
-        v-if="policy && !isEmpty(policy)"
+        v-if="isPolicySelected"
         type="button"
         class="btn role-link show-policy"
         data-testid="k3k-policy-open-drawer"
@@ -307,11 +356,28 @@ export default {
       </button>
     </div>
     <div class="col span-6">
-      <LabeledSelect
+      <LabeledSelectWithCreate
+        v-if="!isPolicySelected"
         :value="targetNamespace"
         :loading="showLoadingSpinner"
         :mode="mode"
-        :disabled="!isCreate"
+        :disabled="!hostClusterId || !isCreate"
+        :label="t('k3k.targetNamespace.label')"
+        :options="namespaceOptions"
+        :rules="rules.namespace"
+        :placeholder="t('k3k.targetNamespace.placeholder')"
+        required
+        @update:value="e=>$emit('update:targetNamespace', e)"
+        @creating="onNamespaceCreating"
+        @create="onNamespaceCreate"
+        @cancel="cancelCreateNamespace"
+      />
+      <LabeledSelect
+        v-else
+        :value="targetNamespace"
+        :loading="showLoadingSpinner"
+        :mode="mode"
+        :disabled="!hostClusterId || !isCreate"
         :label="t('k3k.targetNamespace.label')"
         :options="namespaceOptions"
         :rules="rules.namespace"

--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -228,22 +228,17 @@ export default {
         return false;
       }
 
-      try {
-        await this.$store.dispatch('management/request', {
-          url:    `/k8s/clusters/${ this.hostClusterId }/v1/${ NAMESPACE }`,
-          method: 'POST',
-          data:   {
-            apiVersion: 'v1',
-            kind:       'Namespace',
-            metadata:   { name: this.targetNamespace },
-          },
-        });
+      await this.$store.dispatch('management/request', {
+        url:    `/k8s/clusters/${ this.hostClusterId }/v1/${ NAMESPACE }`,
+        method: 'POST',
+        data:   {
+          apiVersion: 'v1',
+          kind:       'Namespace',
+          metadata:   { name: this.targetNamespace },
+        },
+      });
 
-        return true;
-      } catch (e) {
-        this.namespaceError = true;
-        throw e;
-      }
+      return true;
     }
   },
 
@@ -352,7 +347,8 @@ export default {
         :label="t('k3k.policy.label')"
         :placeholder="t('k3k.policy.placeholder')"
         :options="policyOptions"
-        :hover-tooltip="false"
+        :rules="rules.policy"
+        required
         @update:value="e=>$emit('update:policy', e)"
       />
       <span

--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -374,6 +374,7 @@ export default {
     </div>
     <div class="col span-6">
       <LabeledSelectWithCreate
+        :key="isPolicySelected"
         :value="targetNamespace"
         :loading="showLoadingSpinner"
         :mode="mode"

--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -81,7 +81,7 @@ export default {
       loadingPoliciesAndNamespaces: false,
       namespaceError:               false,
       policyError:                  false,
-      previousTargetNamespace:      '',
+      previousTargetNamespace:      ''
     };
   },
 
@@ -253,6 +253,13 @@ export default {
       return mgmt?.id;
     },
 
+    // project-scoped RBAC only propagates into namespaces backed by a project, so only
+    // users with cluster-level permissions can create resources in projectless namespaces -
+    // mirrors Dashboard's own canSeeProjectlessNamespaces (ExplorerProjectsNamespaces.vue)
+    canCreateInProjectlessNamespaces() {
+      return !!this.hostCluster?.mgmt?.canUpdate;
+    },
+
     namespaceIdsByProject() {
       const out = { none: [] };
 
@@ -277,7 +284,7 @@ export default {
     },
 
     policyOptions() {
-      return [{ label: this.t('generic.none'), value: {} }, ...this.policies.reduce((hasNs, p) => {
+      return [{ label: this.t('k3k.policy.noneOption'), value: {} }, ...this.policies.reduce((hasNs, p) => {
         const projectIds = (getProjectIds(p) || []);
 
         const hasNamespaces = (projectIds).find((p) => this.namespaceIdsByProject[p]);
@@ -340,7 +347,7 @@ export default {
       class="col span-6"
     >
       <LabeledSelect
-        :value="isPolicySelected ? policy : (isNoneSelected ? t('generic.none') : null)"
+        :value="isPolicySelected ? policy : (isNoneSelected ? t('k3k.policy.noneOption') : null)"
         :loading="showLoadingSpinner"
         :disabled="!hostClusterId || !k3kInstalled || !isCreate"
         :mode="mode"
@@ -367,7 +374,6 @@ export default {
     </div>
     <div class="col span-6">
       <LabeledSelectWithCreate
-        v-if="!isPolicySelected"
         :value="targetNamespace"
         :loading="showLoadingSpinner"
         :mode="mode"
@@ -377,22 +383,11 @@ export default {
         :rules="rules.namespace"
         :placeholder="t('k3k.targetNamespace.placeholder')"
         :create-label="t('k3k.targetNamespace.createLabel')"
+        :create-allowed="!isPolicySelected && canCreateInProjectlessNamespaces"
         required
         @update:value="e=>$emit('update:targetNamespace', e)"
         @creating="onNamespaceCreating"
         @cancel="cancelCreateNamespace"
-      />
-      <LabeledSelect
-        v-else
-        :value="targetNamespace"
-        :loading="showLoadingSpinner"
-        :mode="mode"
-        :disabled="!hostClusterId || !isCreate || isPolicyUnset"
-        :label="t('k3k.targetNamespace.label')"
-        :options="namespaceOptions"
-        :rules="rules.namespace"
-        :require-dirty="false"
-        @update:value="e=>$emit('update:targetNamespace', e)"
       />
     </div>
   </div>

--- a/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/ClusterPolicy.vue
@@ -81,41 +81,22 @@ export default {
       loadingPoliciesAndNamespaces: false,
       namespaceError:               false,
       policyError:                  false,
-      namespaceCreating:            false,
       previousTargetNamespace:      '',
     };
   },
 
   watch: {
     hostClusterId(neu) {
-      this.$emit('update:policy', {});
+      // policy is unset (not an explicit None) until we know what's available for the new host cluster
+      this.$emit('update:policy', null);
       this.$emit('update:targetNamespace', '');
       if (neu) {
         this.fetchPolicies();
       }
     },
 
-    policyOptions(neu = [], old = []) {
-      if (this.mode !== _CREATE) {
-        return;
-      }
-
-      const policyIds = (opts) => opts.map((p) => p?.value?.metadata?.name || '').join('|');
-
-      // We need this check because the policy options get recalculated when new namespace is added
-      if (policyIds(neu) === policyIds(old)) {
-        return;
-      }
-
-      // only preset the policy on create when there's a single unambiguous option
-      const realPolicyOptions = neu.filter((p) => !!p?.value);
-
-      this.$emit('update:policy', realPolicyOptions.length === 1 ? realPolicyOptions[0].value : null);
-      this.$emit('update:targetNamespace', '');
-    },
-
     namespaceOptions(neu = []) {
-      if (this.mode !== _CREATE || neu.includes(this.targetNamespace)) {
+      if (this.mode !== _CREATE) {
         return;
       }
 
@@ -169,7 +150,31 @@ export default {
           }
         }
 
-        return await this.fetchNamespaces();
+        await this.fetchNamespaces();
+
+        if (this.mode === _CREATE) {
+          this.presetPolicyIfUnambiguous();
+        }
+      }
+    },
+
+    // only preset the policy on create, and only when there's a single
+    // unambiguous outcome - either exactly one real policy, or none at all
+    // (in which case None is the only possible choice). With 2+ real
+    // policies available it's left null, waiting on the user to choose.
+    presetPolicyIfUnambiguous() {
+      if (this.policy !== null) {
+        return;
+      }
+
+      const realPolicyOptions = this.policyOptions.filter((p) => !isEmpty(p?.value));
+
+      if (realPolicyOptions.length === 1) {
+        this.$emit('update:policy', realPolicyOptions[0].value);
+        this.$emit('update:targetNamespace', '');
+      } else if (realPolicyOptions.length === 0) {
+        this.$emit('update:policy', {});
+        this.$emit('update:targetNamespace', '');
       }
     },
 
@@ -205,20 +210,24 @@ export default {
       // we should show 'none' in that case
       const policyObject = this.policies.find((p) => p?.metadata?.name === policyName);
 
-      if (policyObject) {
-        this.$emit('update:policy', policyObject);
-      }
+      this.$emit('update:policy', policyObject || {});
     },
 
     isEmpty,
 
     onNamespaceCreating() {
       this.previousTargetNamespace = this.targetNamespace;
-      this.namespaceCreating = true;
     },
 
-    async onNamespaceCreate(name) {
-      this.namespaceCreating = false;
+    cancelCreateNamespace() {
+      this.$emit('update:targetNamespace', this.previousTargetNamespace);
+    },
+
+    async createNamespaceIfNeeded() {
+      if (!this.targetNamespace || this.namespaces.some((ns) => ns.id === this.targetNamespace)) {
+        return false;
+      }
+
       try {
         await this.$store.dispatch('management/request', {
           url:    `/k8s/clusters/${ this.hostClusterId }/v1/${ NAMESPACE }`,
@@ -226,21 +235,16 @@ export default {
           data:   {
             apiVersion: 'v1',
             kind:       'Namespace',
-            metadata:   { name },
+            metadata:   { name: this.targetNamespace },
           },
         });
-        await this.fetchNamespaces();
-        this.$emit('update:targetNamespace', name);
+
+        return true;
       } catch (e) {
         this.namespaceError = true;
-        this.$emit('update:targetNamespace', this.previousTargetNamespace);
+        throw e;
       }
-    },
-
-    cancelCreateNamespace() {
-      this.namespaceCreating = false;
-      this.$emit('update:targetNamespace', this.previousTargetNamespace);
-    },
+    }
   },
 
   computed: {
@@ -278,7 +282,7 @@ export default {
     },
 
     policyOptions() {
-      return [{ label: this.t('generic.none'), value: null }, ...this.policies.reduce((hasNs, p) => {
+      return [{ label: this.t('generic.none'), value: {} }, ...this.policies.reduce((hasNs, p) => {
         const projectIds = (getProjectIds(p) || []);
 
         const hasNamespaces = (projectIds).find((p) => this.namespaceIdsByProject[p]);
@@ -310,6 +314,15 @@ export default {
     },
     isPolicySelected() {
       return this.policy && !isEmpty(this.policy);
+    },
+
+    isNoneSelected() {
+      return !!this.policy && isEmpty(this.policy);
+    },
+
+    // nothing has been chosen yet (ambiguous, waiting on the user)
+    isPolicyUnset() {
+      return !this.policy;
     }
   },
 };
@@ -332,17 +345,18 @@ export default {
       class="col span-6"
     >
       <LabeledSelect
-        :value="isPolicySelected ? policy : t('generic.none')"
+        :value="isPolicySelected ? policy : (isNoneSelected ? t('generic.none') : null)"
         :loading="showLoadingSpinner"
         :disabled="!hostClusterId || !k3kInstalled || !isCreate"
         :mode="mode"
         :label="t('k3k.policy.label')"
+        :placeholder="t('k3k.policy.placeholder')"
         :options="policyOptions"
         :hover-tooltip="false"
         @update:value="e=>$emit('update:policy', e)"
       />
       <span
-        v-if="!policy && !showLoadingSpinner"
+        v-if="isNoneSelected && !showLoadingSpinner"
         class="nonepolicy-warning text-deemphasized"
       ><i class="icon icon-warning" />{{ t('k3k.policy.noneWarning') }}</span>
       <button
@@ -361,15 +375,15 @@ export default {
         :value="targetNamespace"
         :loading="showLoadingSpinner"
         :mode="mode"
-        :disabled="!hostClusterId || !isCreate"
+        :disabled="!hostClusterId || !isCreate || isPolicyUnset"
         :label="t('k3k.targetNamespace.label')"
         :options="namespaceOptions"
         :rules="rules.namespace"
         :placeholder="t('k3k.targetNamespace.placeholder')"
+        :create-label="t('k3k.targetNamespace.createLabel')"
         required
         @update:value="e=>$emit('update:targetNamespace', e)"
         @creating="onNamespaceCreating"
-        @create="onNamespaceCreate"
         @cancel="cancelCreateNamespace"
       />
       <LabeledSelect
@@ -377,7 +391,7 @@ export default {
         :value="targetNamespace"
         :loading="showLoadingSpinner"
         :mode="mode"
-        :disabled="!hostClusterId || !isCreate"
+        :disabled="!hostClusterId || !isCreate || isPolicyUnset"
         :label="t('k3k.targetNamespace.label')"
         :options="namespaceOptions"
         :rules="rules.namespace"

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -311,6 +311,18 @@ export default {
           rootObject: this.k3kCluster,
           rules:      ['namespaceRequired']
         },
+        {
+          path:           'policyForValidation',
+          rootObject:     this,
+          rules:          ['required'],
+          translationKey: 'k3k.policy.label'
+        },
+        {
+          path:           'parentCluster.id',
+          rootObject:     this,
+          rules:          ['required'],
+          translationKey: 'k3k.hostCluster.label'
+        },
       ],
       /**
        * store k3kCluster and provisioning cluster configuration immediately before saving/importing the cluster
@@ -338,6 +350,10 @@ export default {
           return !ns ? this.t('validation.required', { key: this.t('tableHeaders.namespace') }) : null;
         }
       };
+    },
+
+    policyForValidation() {
+      return this.policy === null ? '' : this.policy;
     },
 
     isCreate() {
@@ -748,6 +764,7 @@ export default {
           v-model:k3k-installed="k3kInstalled"
           :mode="mode"
           :clusters="provClusters"
+          :rules="{hostCluster: fvGetAndReportPathRules('parentCluster.id')}"
           @error="handleInstallationError"
         />
 
@@ -758,7 +775,7 @@ export default {
           :host-cluster="parentCluster"
           :k3k-installed="k3kInstalled"
           :mode="mode"
-          :rules="{namespace:fvGetAndReportPathRules('metadata.namespace')}"
+          :rules="{namespace:fvGetAndReportPathRules('metadata.namespace'), policy:fvGetAndReportPathRules('policyForValidation')}"
         />
 
         <div class="row mb-20">

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -20,7 +20,7 @@ import { RcSection } from '@components/RcSection';
 import { RcCounterBadge } from '@components/Pill';
 
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor';
-import { CAPI, MANAGEMENT } from '@shell/config/types';
+import { CAPI, MANAGEMENT, NAMESPACE } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
@@ -522,9 +522,13 @@ export default {
       this.k3kClusterBeforeSave = cloneDeep(this.k3kCluster);
 
       const cluster = await this.findNormanCluster();
+      let createdNamespace = false;
 
       try {
         if (this.mode === _CREATE) {
+          // create the target namespace first
+          createdNamespace = await this.$refs.clusterPolicy.createNamespaceIfNeeded();
+
           // create the k3k cluster crd
           await this.createCluster();
 
@@ -552,7 +556,7 @@ export default {
         const cb = async(passed) => {
           if (!passed && this.mode === _CREATE) {
             try {
-              await this.deleteResourcesForRedo();
+              await this.deleteResourcesForRedo(createdNamespace);
             } catch (e) {
               this.errors.push(e);
 
@@ -570,10 +574,16 @@ export default {
       }
     },
 
-    // if created, delete the k3k cluster and provisioning cluster and reset this.k3kCluster and this.localValue (prov cluster) so that the user can retry clicking save
+    // if created, delete the k3k cluster, provisioning cluster and (if we created one)
+    // the target namespace, and reset this.k3kCluster and this.localValue (prov cluster)
+    // so that the user can retry clicking save
     // only used during create, never edit
-    async deleteResourcesForRedo() {
+    async deleteResourcesForRedo(createdNamespace) {
       const errors = [];
+
+      // capture this before deleteK3kCluster() potentially resets k3kCluster
+      // back to its pre-save (blank) state
+      const namespaceToClean = createdNamespace ? this.k3kCluster?.metadata?.namespace : null;
 
       try {
         await this.deleteK3kCluster();
@@ -585,6 +595,14 @@ export default {
         await this.deleteProvCluster();
       } catch (e) {
         errors.push(e);
+      }
+
+      if (namespaceToClean) {
+        try {
+          await this.deleteNamespace(namespaceToClean);
+        } catch (e) {
+          errors.push(e);
+        }
       }
 
       // If any errors occurred, throw them
@@ -635,6 +653,20 @@ export default {
       } catch (e) {
         // warn users the prov cluster might still exist
         throw new Error(`${ this.t('k3k.errors.deletingProvCluster') }\n${ e?.message || e }`);
+      }
+    },
+
+    // best-effort rollback for a namespace ClusterPolicy created via createNamespaceIfNeeded
+    async deleteNamespace(name) {
+      try {
+        const cluster = await this.findNormanCluster();
+
+        await this.$store.dispatch('management/request', {
+          url:    `/k8s/clusters/${ cluster?.id }/v1/${ NAMESPACE }/${ name }`,
+          method: 'DELETE',
+        });
+      } catch (e) {
+        throw new Error(`${ this.t('k3k.errors.deletingNamespace') }\n${ e?.message || e }`);
       }
     },
 
@@ -720,6 +752,7 @@ export default {
         />
 
         <ClusterPolicy
+          ref="clusterPolicy"
           v-model:target-namespace="k3kCluster.metadata.namespace"
           v-model:policy="policy"
           :host-cluster="parentCluster"

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -334,9 +334,7 @@ export default {
 
     fvExtraRules() {
       return {
-        namespaceRequired: () => {
-          const ns = this.k3kCluster?.metadata?.namespace;
-
+        namespaceRequired: (ns) => {
           return !ns ? this.t('validation.required', { key: this.t('tableHeaders.namespace') }) : null;
         }
       };

--- a/pkg/virtual-clusters/components/InstallK3k.vue
+++ b/pkg/virtual-clusters/components/InstallK3k.vue
@@ -97,7 +97,7 @@ export default {
   watch: {
     parentClusterOptions: {
       handler(neu = []) {
-        if (!this.parentCluster?.id && neu.length) {
+        if (!this.parentCluster?.id && neu.length === 1) {
           this.selectedParentOption = neu[0].value;
         }
       },
@@ -347,6 +347,8 @@ export default {
         :disabled="!isCreate"
         :options="parentClusterOptions"
         :loading="loadingClusters"
+        :placeholder="t('k3k.hostCluster.placeholder')"
+        required
       />
     </div>
     <div

--- a/pkg/virtual-clusters/components/InstallK3k.vue
+++ b/pkg/virtual-clusters/components/InstallK3k.vue
@@ -73,6 +73,13 @@ export default {
     showButtonOnly: {
       type:    Boolean,
       default: false
+    },
+
+    rules: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
     }
   },
 
@@ -348,6 +355,7 @@ export default {
         :options="parentClusterOptions"
         :loading="loadingClusters"
         :placeholder="t('k3k.hostCluster.placeholder')"
+        :rules="rules.hostCluster"
         required
       />
     </div>

--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -5,6 +5,7 @@ k3k:
     label: Virtual Cluster Policy
     placeholder: Select a policy
     noneWarning: Clusters created without a policy should only be used for testing purposes.
+    noneOption: No policy
     tabs:
       config: Config
       resourceSync: Resource Synchronization

--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -140,6 +140,7 @@ k3k:
     viewPolicy: View Policy Configuration
   targetNamespace:
     label: Target Namespace
+    placeholder: Select the target namespace or create a new one
   hostCluster:
     label: Host cluster
     placeholder: The cluster that will host this virtual cluster

--- a/pkg/virtual-clusters/l10n/en-us.yaml
+++ b/pkg/virtual-clusters/l10n/en-us.yaml
@@ -3,6 +3,7 @@ k3k:
   label: K3K
   policy:
     label: Virtual Cluster Policy
+    placeholder: Select a policy
     noneWarning: Clusters created without a policy should only be used for testing purposes.
     tabs:
       config: Config
@@ -141,6 +142,7 @@ k3k:
   targetNamespace:
     label: Target Namespace
     placeholder: Select the target namespace or create a new one
+    createLabel: Create a new Namespace
   hostCluster:
     label: Host cluster
     placeholder: The cluster that will host this virtual cluster
@@ -265,6 +267,7 @@ k3k:
     deletingClusterGeneric: Error deleting cluster
     deletingProvCluster: 'Cluster creation and registration has failed but a Rancher cluster resource may have been created. Check the cluster management list view before trying again.'
     deletingK3kCluster: 'Cluster creation and registration has failed but a K3K cluster resource may have been created. Check the host cluster before trying again.'
+    deletingNamespace: 'Cluster creation and registration has failed but the target namespace may have been created. Check the host cluster before trying again.'
     creatingAndRegisteringCluster: 'There was an error creating the virtual cluster:'
   landingPage:
     title: Virtual Clusters


### PR DESCRIPTION
Fixes #114 #76 
Requires https://github.com/rancher/dashboard/pull/18512

Changes:
- Added 'Create new' option for target namespaces when No policy is selected
- Removed default value for Host cluster unless there is only one available cluster
- Since we do not pre-select host cluster anymore, I disabled selecting target namespace until host cluster is picked
- For Policy:
    - If no policy available:
       Policy -> None
       Namespace -> Default

       If only one policy available:
       Policy -> auto-select
      Namespace -> Default

      If several policies available:
      Policy -> Enabled, empty
       Namespace -> Disabled, empty

Testing:
1. Namespace creation
Select a host cluster with k3k installed.
In the Target Namespace field, choose "Create new…", type a new namespace name, and confirm.
Verify no validation error is shown while typing (previously showed "required" the whole time).
Verify the new namespace is created and selected as the target namespace.
Cancel out of the "create new" input after typing something — verify the field reverts to the previously selected namespace.
2. Host cluster default selection
With only one eligible host cluster available, verify it is preselected automatically.
With more than one eligible host cluster available, verify none is preselected — you must choose one explicitly.
3. Policy default selection
With no policies available, verify that None is preselected
With exactly one selectable policy available (i.e. exactly one policy that already has a namespace assigned to it), verify it is preselected automatically after choosing a host cluster.
With more than one selectable policy available, verify nothing is selected by default — no policy is auto-picked. Namespace should be disabled until an option is picked
4. Target namespace default selection
Select a policy (not "None") — verify the target namespace is preset to the first available namespace under that policy.
Switch the policy back to "None" — verify the target namespace is cleared instead of being preset to the first available namespace.
5. Field disabling
Before selecting a host cluster, verify the Target Namespace field (both the plain select and the "create new" variant) is disabled.
After selecting a host cluster, verify the Target Namespace field becomes enabled.
6. Validation
Try to save with no target namespace selected — verify a "required" validation error is shown.
Select/create a valid target namespace — verify the error clears.

https://github.com/user-attachments/assets/1164f78c-9194-4981-9034-17812e52f2af

The error screen is because I recorded this with rancher 2.14 while running master dashboard