### PR TITLE
fix issue showing inputs when no policy selected

### DIFF
--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -48,7 +48,7 @@ import importConfigMapTemplate from '../../resources/import-configmap.json';
 import importJobTemplate from '../../resources/import-job.json';
 import merge from 'lodash/merge';
 import { set } from '@shell/utils/object';
-import  isEmpty  from 'lodash/isEmpty';
+import isEmpty from 'lodash/isEmpty';
 
 // Pinned fallback for the cluster import job image; used when the
 // 'shell-image' setting is empty. Kept in sync with the rancher/shell
@@ -361,7 +361,7 @@ export default {
       return this.policy === null ? '' : this.policy;
     },
 
-    hasPolicy(){
+    hasPolicy() {
       return this.policy && !isEmpty(this.policy)
     },
 

--- a/pkg/virtual-clusters/components/CruK3KCluster/index.vue
+++ b/pkg/virtual-clusters/components/CruK3KCluster/index.vue
@@ -48,6 +48,7 @@ import importConfigMapTemplate from '../../resources/import-configmap.json';
 import importJobTemplate from '../../resources/import-job.json';
 import merge from 'lodash/merge';
 import { set } from '@shell/utils/object';
+import  isEmpty  from 'lodash/isEmpty';
 
 // Pinned fallback for the cluster import job image; used when the
 // 'shell-image' setting is empty. Kept in sync with the rancher/shell
@@ -358,6 +359,10 @@ export default {
 
     policyForValidation() {
       return this.policy === null ? '' : this.policy;
+    },
+
+    hasPolicy(){
+      return this.policy && !isEmpty(this.policy)
     },
 
     isCreate() {
@@ -712,7 +717,7 @@ export default {
           resource: CAPI.RANCHER_CLUSTER,
         },
       });
-    },
+    }
   }
 };
 </script>
@@ -796,7 +801,7 @@ export default {
         </div>
 
         <template
-          v-if="!policy"
+          v-if="!hasPolicy"
         >
           <Mode
             v-model:k3k-mode="k3kCluster.spec.mode"
@@ -814,7 +819,7 @@ export default {
         />
       </Tab>
       <Tab
-        v-if="!policy"
+        v-if="!hasPolicy"
         name="sync"
         label-key="k3k.policy.tabs.resourceSync"
         :weight="10"
@@ -911,7 +916,7 @@ export default {
           </div>
         </div>
         <div
-          v-if="!policy"
+          v-if="!hasPolicy"
           class="row mt-40 mb-20"
         >
           <div class="col span-12">
@@ -935,7 +940,7 @@ export default {
         </div>
       </Tab>
       <Tab
-        v-if="!policy && supportsTopology"
+        v-if="!hasPolicy && supportsTopology"
         name="affinity"
         label-key="k3k.policy.tabs.topology"
         :weight="8"


### PR DESCRIPTION
#193

It looks like this bug was introduced [here](https://github.com/rancher/virtual-clusters-ui/pull/158/changes#diff-afc369229066e742ce96a291662de3c6864f4b75d307de2bf7b4657035279e87L235) - When users select "No Policy" the value of policy is set to an empty object instead of null so `v-if="!policy"` template conditions were never true.

https://github.com/user-attachments/assets/8f6b9b82-2a49-43d1-a91a-daf452f48f51


