### PR TITLE
clear storage class selector when storage class sync is disabled

### DIFF
--- a/pkg/virtual-clusters/components/Sync/StorageClasses.vue
+++ b/pkg/virtual-clusters/components/Sync/StorageClasses.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import debounce from 'lodash/debounce';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
@@ -63,6 +63,10 @@ const storageClassEnabled = computed({
   get: () => props.enabled,
   set: (neu) => {
     emit('update:enabled', neu);
+    //changing enabled and selector each trigger update:storageClasses from the parent component - nextTick avoids timing issue
+    nextTick(() => {
+      storageClassSelector.value = undefined
+    })
   }
 });
 

--- a/pkg/virtual-clusters/components/Sync/StorageClasses.vue
+++ b/pkg/virtual-clusters/components/Sync/StorageClasses.vue
@@ -63,10 +63,12 @@ const storageClassEnabled = computed({
   get: () => props.enabled,
   set: (neu) => {
     emit('update:enabled', neu);
-    //changing enabled and selector each trigger update:storageClasses from the parent component - nextTick avoids timing issue
-    nextTick(() => {
-      storageClassSelector.value = undefined
-    })
+     // Changing `enabled` and `selector` both trigger `update:storageClasses` in the parent; defer selector clearing to avoid overwriting the enabled update.
+     if (!neu && props.selector) {
+       nextTick(() => {
+         emit('update:selector', undefined);
+       });
+     }
   }
 });
 


### PR DESCRIPTION
#181

This PR updates the storage synchronization UI to clear out selector configuration when storage class sync is disabled. The original scenario in 181 should be tested as well as:

1. create a new vcp, define a storage class synchronization selector, and click save. Verify that the selector is saved
2. Edit the vcp from step 1 and verify that the selector is displayed.
3. Edit the vcp from step 1 to toggle the 'All Storage Classes' button to hide the selector and click save. Verify the selectors are not sent in the network request to update the vcp
4. Create anther vcp, define a storage class synchronization selector, and save
5. Edit the vcp from step 4, disable storage class sync, click save. Verify that the `sync.storageClasses.enabled` property is `false` and that `sync.storageClasses.selectors` are not saved