### PR TITLE
bump catalog workflow to use creators-pkg-v3.0.12

### DIFF
--- a/.github/workflows/build--extension-catalog.yml
+++ b/.github/workflows/build--extension-catalog.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build-extension-catalog:
-    uses: rancher/dashboard/.github/workflows/build-extension-catalog.yml@9eb70a732e9be146722e1dbab431338366c2afc6 # creators-pkg-v3.0.10
+    uses: rancher/dashboard/.github/workflows/build-extension-catalog.yml@9bf23dff6650116673346447bcf0b088e0edb27f # creators-pkg-v3.0.12
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
The catalog-publishing workflow has been broken for a bit ([example](https://github.com/rancher/virtual-clusters-ui/actions/runs/33086682445/job/98568115548))...I'm not sure if anyone installs the extension this way given we're also publishing it to the official extensions repository, buuut this looks like a simple fix.

I tested this on my fork and it looks like just bumping the version (same commit used in the other build/publish workflow) will fix the error above - https://github.com/mantis-toboggan-md/virtual-clusters-ui/actions/runs/33123036536/job/98694416449