### PR TITLE
fix: guard against missing status on freshly-created ClusterRepo during K3K install

### DIFF
--- a/pkg/virtual-clusters/components/InstallK3k.vue
+++ b/pkg/virtual-clusters/components/InstallK3k.vue
@@ -263,7 +263,7 @@ export default {
             url:    k3kRepoUrl,
             method: 'GET',
           });
-          const downloadedCondition = k3kRepo.status.conditions.find((s) => s.type === 'OCIDownloaded');
+          const downloadedCondition = k3kRepo.status?.conditions?.find((s) => s.type === 'OCIDownloaded');
 
           const downloaded = downloadedCondition?.status === 'True';
 


### PR DESCRIPTION
Signed-off-by: Jeroen van Erp <jeroen@hierynomus.com>